### PR TITLE
Improve error reporting

### DIFF
--- a/custom_components/custom_conversation/const.py
+++ b/custom_components/custom_conversation/const.py
@@ -25,6 +25,7 @@ LLM_API_ID = "custom-conversation"
 HOME_ASSISTANT_AGENT = "conversation.home_assistant"
 CONVERSATION_STARTED_EVENT = f"{DOMAIN}_conversation_started"
 CONVERSATION_ENDED_EVENT = f"{DOMAIN}_conversation_ended"
+CONVERSATION_ERROR_EVENT = f"{DOMAIN}_conversation_error"
 
 CONF_CUSTOM_PROMPTS_SECTION = "custom_prompts"
 CONF_PROMPT_BASE = "prompt_base"

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,13 +1,22 @@
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
+
+from custom_components.custom_conversation import CustomConversationConfigEntry
+from custom_components.custom_conversation.const import (
+    CONF_AGENTS_SECTION,
+    CONF_ENABLE_HASS_AGENT,
+    CONF_ENABLE_LLM_AGENT,
+    CONVERSATION_ERROR_EVENT,
+    LLM_API_ID,
+)
+from custom_components.custom_conversation.conversation import CustomConversationEntity
 from homeassistant.components import conversation
 from homeassistant.const import CONF_LLM_HASS_API
-from homeassistant.core import HomeAssistant, Context
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
-from unittest.mock import Mock, patch
-from custom_components.custom_conversation.conversation import CustomConversationEntity
-from custom_components.custom_conversation.const import CONF_AGENTS_SECTION, CONF_ENABLE_HASS_AGENT, CONF_ENABLE_LLM_AGENT, LLM_API_ID
-from custom_components.custom_conversation import CustomConversationConfigEntry
 
 
 async def test_custom_conversation_entity_initialization(hass: HomeAssistant, config_entry: CustomConversationConfigEntry):
@@ -90,3 +99,168 @@ async def test_custom_conversation_llm_api_disabled(hass: HomeAssistant, config_
     assert result.conversation_id == "test-conversation-id"
     assert mock_process_hass.called
     assert not result.response.error_code
+
+async def test_custom_conversation_rate_limit_error(hass: HomeAssistant, config_entry: CustomConversationConfigEntry):
+    """Test that rate limit errors are properly handled and event is fired."""
+    assert await async_setup_component(hass, "custom_conversation", {})
+    await hass.async_block_till_done()
+
+    # Mock the process_hass method to return an error to force using LLM agent
+    mock_response = intent.IntentResponse(language="en", intent=Mock())
+    mock_response.error_code = intent.IntentResponseErrorCode.UNKNOWN
+    mock_result = conversation.ConversationResult(mock_response, "test-conversation-id")
+
+    class MockRateLimitError(Exception):
+        """Mock for RateLimitError that works with try/except."""
+
+        def __init__(self):
+            super().__init__("Rate limited - out of quota")
+            self.body = "Rate limited - out of quota"
+
+        def __str__(self):
+            return "Rate limited - out of quota"
+
+    rate_limit_error = MockRateLimitError()
+
+    events = []
+    hass.bus.async_listen(CONVERSATION_ERROR_EVENT, lambda e: events.append(e))
+
+    with patch(
+        "custom_components.custom_conversation.conversation.CustomConversationEntity._async_process_hass", 
+        return_value=mock_result
+    ), patch(
+        "custom_components.custom_conversation.conversation.CustomConversationEntity._async_process_llm", 
+        side_effect=rate_limit_error
+    ), patch(
+        "custom_components.custom_conversation.conversation.openai.RateLimitError", 
+        MockRateLimitError
+    ), patch(
+        "custom_components.custom_conversation.conversation.CustomConversationEntity._async_fire_conversation_error",
+        AsyncMock()
+    ) as mock_fire_error:
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            options={
+                **config_entry.options,
+                CONF_LLM_HASS_API: LLM_API_ID,
+                CONF_AGENTS_SECTION: {
+                    CONF_ENABLE_HASS_AGENT: True,
+                    CONF_ENABLE_LLM_AGENT: True,
+                },
+            },
+        )
+        await hass.config_entries.async_reload(config_entry.entry_id)
+
+        with pytest.raises(HomeAssistantError, match="Rate limited or insufficient funds"):
+            await conversation.async_converse(
+                hass, "hello", "test-conversation-id", Context(), agent_id=config_entry.entry_id
+            )
+
+        assert mock_fire_error.called
+        call_args = mock_fire_error.call_args[0]
+        assert call_args[0] == str(rate_limit_error)  # Now checking the string value
+        assert call_args[1] == "LLM"
+
+async def test_custom_conversation_openai_error(hass: HomeAssistant, config_entry: CustomConversationConfigEntry):
+    """Test that general OpenAI errors are properly handled and event is fired."""
+    assert await async_setup_component(hass, "custom_conversation", {})
+    await hass.async_block_till_done()
+
+    # Set up a custom async_process to raise a HomeAssistantError directly
+    # This simulates the process failing with OpenAIError and converting it to HomeAssistantError
+    async def mock_process(user_input):
+        await entity._async_fire_conversation_error(
+            "API connection error", "LLM", user_input, None
+        )
+        raise HomeAssistantError("Error talking to OpenAI API")
+
+    entity = CustomConversationEntity(config_entry, Mock())
+    entity.hass = hass
+
+    with patch.object(
+        CustomConversationEntity,
+        "async_process",
+        side_effect=mock_process
+    ):
+
+        hass.config_entries.async_update_entry(
+            config_entry,
+            options={
+                **config_entry.options,
+                CONF_LLM_HASS_API: LLM_API_ID,
+                CONF_AGENTS_SECTION: {
+                    CONF_ENABLE_HASS_AGENT: True,
+                    CONF_ENABLE_LLM_AGENT: True,
+                },
+            },
+        )
+        await hass.config_entries.async_reload(config_entry.entry_id)
+
+        events = []
+        hass.bus.async_listen(CONVERSATION_ERROR_EVENT, lambda e: events.append(e))
+
+        user_input = conversation.ConversationInput(
+            text="Turn on the lights",
+            context=Context(),
+            conversation_id="test-conversation-id",
+            device_id="test-device-id",
+            language="en",
+            agent_id=config_entry.entry_id
+        )
+
+        # The converse function should raise HomeAssistantError with appropriate message
+        with pytest.raises(HomeAssistantError, match="Error talking to OpenAI API"):
+            await entity.async_process(user_input)
+
+        # Wait for event to be processed
+        await hass.async_block_till_done()
+
+        # Check that the error event was fired
+        assert len(events) == 1
+        event_data = events[0].data
+        assert event_data["agent_id"] == config_entry.entry_id
+        assert event_data["handling_agent"] == "LLM"
+        assert event_data["request"] == "Turn on the lights"
+        assert event_data["error"] == "API connection error"
+
+async def test_async_fire_conversation_error(hass: HomeAssistant, config_entry: CustomConversationConfigEntry):
+    """Test that _async_fire_conversation_error fires the expected event."""
+    assert await async_setup_component(hass, "custom_conversation", {})
+    await hass.async_block_till_done()
+
+    entity = CustomConversationEntity(config_entry, Mock())
+    entity.hass = hass
+
+    events = []
+    hass.bus.async_listen(CONVERSATION_ERROR_EVENT, lambda e: events.append(e))
+
+    user_input = conversation.ConversationInput(
+        text="Turn on the lights",
+        context=Context(),
+        conversation_id="test-conversation-id",
+        device_id="test-device-id",
+        language="en",
+        agent_id=config_entry.entry_id
+    )
+
+    device_data = {
+        "device_name": "Test Device",
+        "device_area": "Living Room"
+    }
+
+
+    error = "Test error message"
+    await entity._async_fire_conversation_error(error, "LLM", user_input, device_data)
+
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    event_data = events[0].data
+    assert event_data["agent_id"] == config_entry.entry_id
+    assert event_data["handling_agent"] == "LLM"
+    assert event_data["device_id"] == "test-device-id"
+    assert event_data["device_name"] == "Test Device"
+    assert event_data["device_area"] == "Living Room"
+    assert event_data["request"] == "Turn on the lights"
+    assert event_data["error"] == "Test error message"


### PR DESCRIPTION
This should resolve #21 . In addition to better handling and reporting errors related to the OpenAI API, those errors are now also published on the service bus, if, for example, one wants to automate a particular action when quota limits are hit.

Example:
```
event_type: custom_conversation_conversation_error
data:
  agent_id: conversation.customconversation_2
  handling_agent: LLM
  device_id: null
  device_name: Unknown
  device_area: Unknown
  request: What's the capital of Wyoming?
  error:
    - error:
        code: 429
        message: >-
          You exceeded your current quota, please check your plan and billing
          details. For more information on this error, head to:
          https://ai.google.dev/gemini-api/docs/rate-limits.
        status: RESOURCE_EXHAUSTED
        details:
          - "@type": type.googleapis.com/google.rpc.QuotaFailure
            violations:
              - quotaMetric: >-
                  generativelanguage.googleapis.com/generate_content_free_tier_requests
                quotaId: GenerateRequestsPerDayPerProjectPerModel-FreeTier
                quotaDimensions:
                  location: global
                  model: gemini-2.5-pro-exp
                quotaValue: "25"
          - "@type": type.googleapis.com/google.rpc.Help
            links:
              - description: Learn more about Gemini API quotas
                url: https://ai.google.dev/gemini-api/docs/rate-limits
          - "@type": type.googleapis.com/google.rpc.RetryInfo
            retryDelay: 50s
origin: LOCAL
time_fired: "2025-04-03T16:28:11.695432+00:00"
context:
  id: 01JQY7PH1F4W7TX5N09RTDZWR5
  parent_id: null
  user_id: null
  ```