### PR TITLE
Prevent langfuse version 3 from being used

### DIFF
--- a/custom_components/custom_conversation/manifest.json
+++ b/custom_components/custom_conversation/manifest.json
@@ -9,6 +9,6 @@
   "issue_tracker": "https://github.com/michelle-avery/custom-conversation/issues",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["langfuse>=2.59.3", "litellm==1.67.2"],
+  "requirements": ["langfuse>=2.59.3,<3", "litellm==1.67.2"],
   "version": "1.2.3"
 }


### PR DESCRIPTION
Version 3 of the Langfuse python library introduces significant non-backwards-compatible changes, so I'm pinning the dependency to <3 until we can make further changes.