### PR TITLE
fix: remove obsolete langfuse v2 kwargs from client constructor

### DIFF
--- a/custom_components/custom_conversation/prompt_manager.py
+++ b/custom_components/custom_conversation/prompt_manager.py
@@ -311,10 +311,6 @@ class LangfuseClient:
                     host=config_entry.options[CONF_LANGFUSE_SECTION].get(
                         CONF_LANGFUSE_HOST
                     ),
-                    enabled=config_entry.options[CONF_LANGFUSE_SECTION][
-                        CONF_LANGFUSE_TRACING_ENABLED
-                    ],
-                    max_retries=0,
                 )
 
             client = await hass.async_add_executor_job(create_client)


### PR DESCRIPTION
**Problem**

The migration from langfuse v2 to v4 (commit `52794c1`) left two v2-only kwargs in the `Langfuse()` constructor in `prompt_manager.py`. Langfuse v4 no longer accepts them, so client initialization raises:

```
TypeError: Langfuse.__init__() got an unexpected keyword argument 'enabled'
```

Because `LangfuseClient` fails to initialize, `PromptManager._langfuse_client` remains `None`, and `_get_langfuse_prompt` silently returns `None` — prompts fall back to the local/Home Assistant template versions instead of being fetched from Langfuse.

**Changes**

- `prompt_manager.py`: remove the obsolete `enabled` and `max_retries` kwargs from the `Langfuse()` constructor. `host` is still valid in v4 and is kept.

**Testing**

Verify by checking that the `_get_langfuse_prompt` observation in Langfuse contains the compiled prompt output instead of `null`.

Fixes #89