### PR TITLE
Fix YAML RepresenterError when an exposed entity's attribute key is an Enum

### DIFF
--- a/custom_components/custom_conversation/api.py
+++ b/custom_components/custom_conversation/api.py
@@ -338,7 +338,7 @@ def _get_exposed_entities(
             info["areas"] = ", ".join(str(n) for n in area_names)
 
         if attributes := {
-            attr_name: str(attr_value)
+            str(attr_name): str(attr_value)
             if isinstance(attr_value, (Enum, Decimal, int))
             else attr_value
             for attr_name, attr_value in state.attributes.items()


### PR DESCRIPTION
## Problem

Building the exposed-entities prompt block crashes with:

```
yaml.representer.RepresenterError: ('cannot represent an object', <EntityStateAttribute.DEVICE_CLASS: 'device_class'>)
```

`state.attributes.items()` can hand back attribute *keys* as `Enum` instances (e.g. `EntityStateAttribute.DEVICE_CLASS`) rather than plain strings, depending on the entity/platform. `_get_exposed_entities()` already stringifies Enum *values*, but not Enum *keys*, before the resulting dict is fed to `homeassistant.util.yaml.dump()`. PyYAML's default representer has no serializer for a bare `Enum`, so any exposed entity carrying such an attribute crashes prompt generation entirely — `Custom Conversation LLM API` becomes unusable for the whole conversation, not just for that one entity.

## Fix

Stringify the attribute key the same way the value is already stringified:

```python
str(attr_name): str(attr_value)
if isinstance(attr_value, (Enum, Decimal, int))
else attr_value
for attr_name, attr_value in state.attributes.items()
if attr_name in interesting_attributes
```

## Testing

Reproduced locally against a HA 2026.7.2 instance with an entity exposing `device_class` as an Enum key, confirmed the crash, applied the one-line fix, restarted, and confirmed the prompt now builds successfully and the entity's attributes render correctly in the exposed-entities YAML block.

This is one of four independent bugs found while debugging `Custom Conversation LLM API` end-to-end; splitting into separate PRs (see also #computed-name-alias-leak, #ignored-intents-not-read, #tool-result-json-serialization) to keep each change reviewable on its own.