### PR TITLE
Fix: ignored-intents option is saved nested but read flat, so the UI setting has no effect

### DIFF
--- a/custom_components/custom_conversation/api.py
+++ b/custom_components/custom_conversation/api.py
@@ -36,7 +36,7 @@ from homeassistant.helpers import (
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.json import JsonObjectType
 
-from .const import CONF_IGNORED_INTENTS, LLM_API_ID
+from .const import CONF_IGNORED_INTENTS, CONF_IGNORED_INTENTS_SECTION, LLM_API_ID
 from .prompt_manager import PromptContext, PromptManager
 
 
@@ -136,8 +136,11 @@ class CustomLLMAPI(llm.API):
         config_entry = self.conversation_config_entry
         # Get ignored intents from options, fallback to defaults
         if config_entry:
+            ignored_intents_section = config_entry.options.get(
+                CONF_IGNORED_INTENTS_SECTION, {}
+            )
             ignore_intents = set(
-                config_entry.options.get(
+                ignored_intents_section.get(
                     CONF_IGNORED_INTENTS, llm.AssistAPI.IGNORE_INTENTS
                 )
             )

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -11,7 +11,11 @@ from custom_components.custom_conversation.api import (
     IntentTool,
     _get_exposed_entities,
 )
-from custom_components.custom_conversation.const import CONF_IGNORED_INTENTS, LLM_API_ID
+from custom_components.custom_conversation.const import (
+    CONF_IGNORED_INTENTS,
+    CONF_IGNORED_INTENTS_SECTION,
+    LLM_API_ID,
+)
 from custom_components.custom_conversation.prompt_manager import (
     PromptContext,
     PromptManager,
@@ -212,7 +216,8 @@ async def test_custom_llm_api_get_tools(custom_llm_api, hass, mock_llm_context, 
     mock_exposed_entities = mock_exposed_entities_data
 
     hass.config_entries.async_update_entry(
-        config_entry, options={CONF_IGNORED_INTENTS: ["HassTurnOff"]}
+        config_entry,
+        options={CONF_IGNORED_INTENTS_SECTION: {CONF_IGNORED_INTENTS: ["HassTurnOff"]}},
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Problem

The options flow saves the ignored-intents selection nested under a config section:

```python
options[CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS]
```

(see `config_flow.py`'s "Ignored Intents Section" schema and the `processed_input.get(CONF_IGNORED_INTENTS_SECTION, {})` handling around the empty-selection default).

But `CustomLLMAPI._async_get_tools()` reads it as a flat top-level key instead:

```python
ignore_intents = set(
    config_entry.options.get(CONF_IGNORED_INTENTS, llm.AssistAPI.IGNORE_INTENTS)
)
```

`config_entry.options.get(CONF_IGNORED_INTENTS)` is always `None` (that key is never set at the top level), so this silently falls back to HA core's default `llm.AssistAPI.IGNORE_INTENTS` list every time, regardless of what the user configured in the UI. There's no error — the setting just has no effect, which is hard to notice without inspecting the actual tool list sent to the LLM.

Concretely: unchecking `HassGetCurrentTime` from the ignore list in the UI does nothing — the tool never appears in the prompt sent to the model.

## Fix

Read the nested section first, then look up the key inside it:

```python
ignored_intents_section = config_entry.options.get(CONF_IGNORED_INTENTS_SECTION, {})
ignore_intents = set(
    ignored_intents_section.get(CONF_IGNORED_INTENTS, llm.AssistAPI.IGNORE_INTENTS)
)
```

## Testing

Reproduced on a HA 2026.7.2 instance: enabled `HassGetCurrentTime` (removed it from the ignore list) via the integration's options UI, confirmed via `--log-prompts-dir` on the llama.cpp backend that the tool was still absent from the rendered prompt before the fix. Applied the fix, restarted, repeated the same UI configuration, and confirmed `HassGetCurrentTime` now appears in the tool list and the model can call it successfully.

One of four independent bugs found while debugging `Custom Conversation LLM API` end-to-end; opened as a separate PR from the others (Enum/YAML crash, tool-result JSON serialization, ComputedNameType alias leak) to keep each change reviewable on its own.