### PR TITLE
Fix: tool results containing non-JSON types (e.g. datetime.time) crash the LLM turn

### DIFF
--- a/custom_components/custom_conversation/conversation.py
+++ b/custom_components/custom_conversation/conversation.py
@@ -190,7 +190,7 @@ def _convert_content_to_param(
         return ChatCompletionToolMessageParam(
             role="tool",
             tool_call_id=content.tool_call_id,
-            content=json.dumps(content.tool_result),
+            content=json.dumps(content.tool_result, default=str),
         )
     if content.role != "assistant" or not content.tool_calls:
         role = content.role


### PR DESCRIPTION
## Problem

`_convert_content_to_param()` serializes a tool's result with a plain `json.dumps(content.tool_result)`. Some HA intents return result payloads containing Python objects that aren't natively JSON-serializable — the concrete case that surfaced this is `HassGetCurrentTime`, whose result includes a raw `datetime.time` object.

This raises:

```
Unexpected error processing LLM stream: Object of type time is not JSON serializable
```

which aborts the entire conversation turn with a generic "LLM response processing failed" error, even though the underlying intent executed successfully — the user just never finds out the time, and gets a confusing failure instead.

## Fix

```python
content=json.dumps(content.tool_result, default=str),
```

`default=str` only kicks in for values `json` can't otherwise encode, so normal JSON types are unaffected; it just stringifies the odd ones (like `datetime.time`) instead of crashing.

## Testing

Reproduced on HA 2026.7.2: asked "Wie ist die aktuelle Uhrzeit?" (What's the current time?), confirmed the crash with `HassGetCurrentTime`'s tool_result containing a `datetime.time` value. Applied the fix, restarted, repeated the same request, and confirmed the model now receives the tool result and answers correctly.

One of four independent bugs found while debugging `Custom Conversation LLM API` end-to-end; opened as a separate PR from the others (Enum/YAML crash, ignored-intents option, ComputedNameType alias leak) to keep each change reviewable on its own.