### PR TITLE
Filter out the COMPUTED_NAME sentinel instead of stringifying it into every alias list

### DIFF
--- a/custom_components/custom_conversation/api.py
+++ b/custom_components/custom_conversation/api.py
@@ -308,7 +308,11 @@ def _get_exposed_entities(
         area_names = []
 
         if entity_entry is not None:
-            names.extend(entity_entry.aliases)
+            names.extend(
+                alias
+                for alias in entity_entry.aliases
+                if alias is not er.COMPUTED_NAME
+            )
             if entity_entry.area_id and (
                 area := area_registry.async_get_area(entity_entry.area_id)
             ):
@@ -416,7 +420,11 @@ def _get_cached_script_parameters(
             if entity_entry.name:
                 aliases.append(entity_entry.name)
             if entity_entry.aliases:
-                aliases.extend(entity_entry.aliases)
+                aliases.extend(
+                    alias
+                    for alias in entity_entry.aliases
+                    if alias is not er.COMPUTED_NAME
+                )
             if aliases:
                 if description:
                     description = description + ". Aliases: " + str(list(aliases))


### PR DESCRIPTION
## Problem

Follow-up to #95 / #96. That fix stopped the crash (`TypeError: sequence item 1: expected str instance, ComputedNameType found`) by stringifying every alias:

```python
"names": ", ".join(str(n) for n in names)
```

But `entity_registry.RegistryEntry.aliases` can contain `homeassistant.helpers.entity_registry.COMPUTED_NAME` — a sentinel (`ComputedNameType._singleton`) meaning "the entity's computed display name should also count as an alias here", not a literal alias string. Stringifying it doesn't crash anymore, but it does turn it into the literal garbage text `ComputedNameType._singleton`, which now shows up as a bogus extra "name" on **almost every exposed entity** that has any alias, e.g.:

```
names: Schlafmodus aktiv, ComputedNameType._singleton
```

The same thing happens a second time in `_get_cached_script_parameters()`, where exposed scripts' descriptions get `Aliases: ['xxx', <ComputedNameType._singleton: 0>]`-style garbage appended.

This bloats the prompt with useless tokens on essentially every entity (verified via `llama-server --log-prompts-dir` on the backend LLM) and risks confusing the model into treating `ComputedNameType._singleton` as a real alias/name it should recognize in user requests.

## Fix

Filter the sentinel out at both places aliases are collected, instead of stringifying it:

```python
names.extend(
    alias
    for alias in entity_entry.aliases
    if alias is not er.COMPUTED_NAME
)
```

and the equivalent change in `_get_cached_script_parameters()`. `state.name` / `entity_entry.name` already carry the computed display name elsewhere in the same info block, so nothing is lost by dropping the sentinel rather than stringifying it.

## Testing

Reproduced on HA 2026.7.2 (where this HA-core computed-name behavior is present): confirmed via raw prompt logs (`llama-server --log-prompts-dir`) that `ComputedNameType._singleton` appeared for nearly every exposed entity and in the `xxx` script's description. Applied the fix, restarted, and confirmed via a fresh prompt log that all occurrences are gone while real aliases (e.g. `Aliases: ['xxx']`) are still rendered correctly.

One of four independent bugs found while debugging `Custom Conversation LLM API` end-to-end; opened as a separate PR from the others (Enum/YAML crash, ignored-intents option, tool-result JSON serialization) to keep each change reviewable on its own.