### PR TITLE
Fix: cannot save an empty ignored-intents selection (ignore nothing)

### DIFF
--- a/custom_components/custom_conversation/config_flow.py
+++ b/custom_components/custom_conversation/config_flow.py
@@ -509,11 +509,13 @@ class CustomConversationOptionsFlow(OptionsFlow):
             if processed_input.get(CONF_LLM_HASS_API) == "none":
                 processed_input.pop(CONF_LLM_HASS_API, None)  # Remove if 'none'
 
-            # Handle empty ignored intents - use default
+            # Only fall back to the default ignore list if the key is truly
+            # absent; a deliberately empty selection (ignore nothing) is a
+            # valid choice and must be preserved as-is.
             ignored_intents_section = processed_input.get(
                 CONF_IGNORED_INTENTS_SECTION, {}
             )
-            if not ignored_intents_section.get(CONF_IGNORED_INTENTS):
+            if CONF_IGNORED_INTENTS not in ignored_intents_section:
                 ignored_intents_section[CONF_IGNORED_INTENTS] = (
                     llm.AssistAPI.IGNORE_INTENTS
                 )

--- a/unit_tests/test_config_flow.py
+++ b/unit_tests/test_config_flow.py
@@ -386,44 +386,6 @@ async def test_options_flow_ignored_intents(hass: HomeAssistant, config_entry):
         assert result["data"][CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS] == test_intents
 
 
-async def test_options_flow_ignored_intents_key_absent_defaults(hass: HomeAssistant, config_entry):
-    """Test config flow options: CONF_IGNORED_INTENTS key missing entirely (not just empty) falls back to the default ignore list."""
-
-    config_entry.add_to_hass(hass)
-    with patch(
-        "custom_components.custom_conversation.async_setup", return_value=True
-    ), patch(
-        "custom_components.custom_conversation.async_setup_entry",
-        return_value=True,
-    ), patch(
-        "homeassistant.helpers.intent.async_get",
-        return_value=[
-            type("Intent", (), {"intent_type": "HassTurnOn"}),
-            type("Intent", (), {"intent_type": "HassTurnOff"}),
-        ],
-    ):
-        result = await hass.config_entries.options.async_init(config_entry.entry_id)
-        assert result["type"] == FlowResultType.FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_IGNORED_INTENTS_SECTION: {},
-                CONF_AGENTS_SECTION: {
-                    CONF_ENABLE_HASS_AGENT: True,
-                    CONF_ENABLE_LLM_AGENT: True,
-                },
-                CONF_TEMPERATURE: DEFAULT_TEMPERATURE,
-                CONF_TOP_P: DEFAULT_TOP_P,
-                CONF_MAX_TOKENS: DEFAULT_MAX_TOKENS,
-                CONF_CUSTOM_PROMPTS_SECTION: {},
-                CONF_LANGFUSE_SECTION: {}
-            },
-        )
-        assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["data"][CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS] == llm.AssistAPI.IGNORE_INTENTS
-
 
 async def test_reconfigure_flow_steps(hass: HomeAssistant, config_entry: MockConfigEntry):
     """Test the full multi-step reconfigure flow."""

--- a/unit_tests/test_config_flow.py
+++ b/unit_tests/test_config_flow.py
@@ -386,6 +386,44 @@ async def test_options_flow_ignored_intents(hass: HomeAssistant, config_entry):
         assert result["data"][CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS] == test_intents
 
 
+async def test_options_flow_ignored_intents_key_absent_defaults(hass: HomeAssistant, config_entry):
+    """Test config flow options: CONF_IGNORED_INTENTS key missing entirely (not just empty) falls back to the default ignore list."""
+
+    config_entry.add_to_hass(hass)
+    with patch(
+        "custom_components.custom_conversation.async_setup", return_value=True
+    ), patch(
+        "custom_components.custom_conversation.async_setup_entry",
+        return_value=True,
+    ), patch(
+        "homeassistant.helpers.intent.async_get",
+        return_value=[
+            type("Intent", (), {"intent_type": "HassTurnOn"}),
+            type("Intent", (), {"intent_type": "HassTurnOff"}),
+        ],
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_IGNORED_INTENTS_SECTION: {},
+                CONF_AGENTS_SECTION: {
+                    CONF_ENABLE_HASS_AGENT: True,
+                    CONF_ENABLE_LLM_AGENT: True,
+                },
+                CONF_TEMPERATURE: DEFAULT_TEMPERATURE,
+                CONF_TOP_P: DEFAULT_TOP_P,
+                CONF_MAX_TOKENS: DEFAULT_MAX_TOKENS,
+                CONF_CUSTOM_PROMPTS_SECTION: {},
+                CONF_LANGFUSE_SECTION: {}
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS] == llm.AssistAPI.IGNORE_INTENTS
+
 
 async def test_reconfigure_flow_steps(hass: HomeAssistant, config_entry: MockConfigEntry):
     """Test the full multi-step reconfigure flow."""

--- a/unit_tests/test_config_flow.py
+++ b/unit_tests/test_config_flow.py
@@ -266,7 +266,7 @@ async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry):
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_API_PROMPT_ID] == "test-api-prompt-id"
 
 async def test_options_flow_empty_fields_reset(hass: HomeAssistant, config_entry):
-    """Test config flow options with empty fields reset to recommended."""
+    """Test config flow options with empty fields reset to recommended (ignored intents empty selection is preserved, not reset)."""
 
     config_entry.add_to_hass(hass)
 
@@ -319,7 +319,7 @@ async def test_options_flow_empty_fields_reset(hass: HomeAssistant, config_entry
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert CONF_LLM_HASS_API not in result["data"]
         assert "agents" in result["data"]
-        assert result["data"][CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS] == llm.AssistAPI.IGNORE_INTENTS
+        assert result["data"][CONF_IGNORED_INTENTS_SECTION][CONF_IGNORED_INTENTS] == []
         assert result["data"][CONF_AGENTS_SECTION][CONF_ENABLE_HASS_AGENT] is True
         assert result["data"][CONF_AGENTS_SECTION][CONF_ENABLE_LLM_AGENT] is False
         # Assert LLM params are direct options


### PR DESCRIPTION
## Problem

`CustomConversationOptionsFlow.async_step_init()` treats an empty `CONF_IGNORED_INTENTS` selection the same as a missing one:

```python
# Handle empty ignored intents - use default
ignored_intents_section = processed_input.get(CONF_IGNORED_INTENTS_SECTION, {})
if not ignored_intents_section.get(CONF_IGNORED_INTENTS):
    ignored_intents_section[CONF_IGNORED_INTENTS] = llm.AssistAPI.IGNORE_INTENTS
    processed_input[CONF_IGNORED_INTENTS_SECTION] = ignored_intents_section
```

The nested field is declared as `vol.Required(CONF_IGNORED_INTENTS, default=...)`, so by the time this code runs the key is *always* present in the section dict — either the user's submitted list (which can legitimately be an empty list, meaning "ignore nothing / expose every intent as a tool") or the schema default if the frontend omitted it entirely. Using `not section.get(CONF_IGNORED_INTENTS)` can't distinguish "explicitly submitted empty list" from "key absent" — both are falsy — so a deliberate, valid choice to leave every intent enabled gets silently discarded and replaced with `llm.AssistAPI.IGNORE_INTENTS` on every save. There's no way to configure "ignore nothing" through the UI; the options flow keeps re-applying the default no matter how the multi-select is submitted.

## Fix

Check for key absence instead of falsiness:

```python
if CONF_IGNORED_INTENTS not in ignored_intents_section:
    ignored_intents_section[CONF_IGNORED_INTENTS] = llm.AssistAPI.IGNORE_INTENTS
    processed_input[CONF_IGNORED_INTENTS_SECTION] = ignored_intents_section
```

This only fills in the default for the (currently unreachable, since the field always has a schema default) case where the key is truly missing, and preserves an explicitly empty selection as-is.

## Testing

Reproduced the logic in isolation against the real HA modules on a HA 2026.7.2 instance (`homeassistant.helpers.llm`, `custom_components.custom_conversation.const`):

- Old logic, explicit empty list submitted (`{CONF_IGNORED_INTENTS: []}`) → incorrectly returns the full default ignore list (10 intents) instead of `[]`.
- New logic, same input → correctly returns `[]`.
- New logic, key entirely absent (`{}`) → correctly falls back to the default ignore list.

Also applied and restarted on the live instance to confirm no regressions to the existing "missing key" fallback path.

One of several independent bugs found while auditing `custom_conversation`'s config flow end-to-end; opened as a separate PR from the others (Enum/YAML crash #103, ignored-intents-not-read #104, tool-result JSON serialization #105, ComputedNameType alias leak #106) to keep each change reviewable on its own.