### PR TITLE
Fix: clearing an optional text field in options flow reverts to old value instead of staying empty

### DIFF
--- a/custom_components/custom_conversation/config_flow.py
+++ b/custom_components/custom_conversation/config_flow.py
@@ -55,6 +55,7 @@ from .const import (
     CONF_PROMPT_EXPOSED_ENTITIES,
     CONF_PROMPT_NO_ENABLED_ENTITIES,
     CONF_PROMPT_TIMERS_UNSUPPORTED,
+    CONF_RESET_PROMPTS_TO_DEFAULT,
     CONF_SECONDARY_API_KEY,
     CONF_SECONDARY_BASE_URL,
     CONF_SECONDARY_CHAT_MODEL,
@@ -525,9 +526,14 @@ class CustomConversationOptionsFlow(OptionsFlow):
             # configured (an options-flow re-edit always has prior values
             # backing the schema's suggested_value). Preserve that as "",
             # rather than reintroducing the old value or a hardcoded default.
+            # The reset checkbox is the escape hatch for users who want the
+            # original built-in prompts back without digging through source.
             prompts = processed_input.get(CONF_CUSTOM_PROMPTS_SECTION, {})
-            for prompt_key in DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION]:
-                prompts.setdefault(prompt_key, "")
+            if prompts.pop(CONF_RESET_PROMPTS_TO_DEFAULT, False):
+                prompts = dict(DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION])
+            else:
+                for prompt_key in DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION]:
+                    prompts.setdefault(prompt_key, "")
             processed_input[CONF_CUSTOM_PROMPTS_SECTION] = prompts
 
             langfuse_options = processed_input.get(CONF_LANGFUSE_SECTION, {})
@@ -689,6 +695,10 @@ class CustomConversationOptionsFlow(OptionsFlow):
                                     )
                                 },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
+                            vol.Optional(
+                                CONF_RESET_PROMPTS_TO_DEFAULT,
+                                default=False,
+                            ): bool,
                         }
                     )
                 ),

--- a/custom_components/custom_conversation/config_flow.py
+++ b/custom_components/custom_conversation/config_flow.py
@@ -526,13 +526,18 @@ class CustomConversationOptionsFlow(OptionsFlow):
             # configured (an options-flow re-edit always has prior values
             # backing the schema's suggested_value). Preserve that as "",
             # rather than reintroducing the old value or a hardcoded default.
-            # The reset checkbox is the escape hatch for users who want the
-            # original built-in prompts back without digging through source.
+            # The reset multi-select is the escape hatch for users who want
+            # individual built-in prompts back without digging through
+            # source; selected keys override whatever was typed/left blank
+            # for that field.
             prompts = processed_input.get(CONF_CUSTOM_PROMPTS_SECTION, {})
-            if prompts.pop(CONF_RESET_PROMPTS_TO_DEFAULT, False):
-                prompts = dict(DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION])
-            else:
-                for prompt_key in DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION]:
+            reset_keys = set(prompts.pop(CONF_RESET_PROMPTS_TO_DEFAULT, []))
+            for prompt_key, prompt_default in DEFAULT_OPTIONS[
+                CONF_CUSTOM_PROMPTS_SECTION
+            ].items():
+                if prompt_key in reset_keys:
+                    prompts[prompt_key] = prompt_default
+                else:
                     prompts.setdefault(prompt_key, "")
             processed_input[CONF_CUSTOM_PROMPTS_SECTION] = prompts
 
@@ -697,8 +702,46 @@ class CustomConversationOptionsFlow(OptionsFlow):
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                             vol.Optional(
                                 CONF_RESET_PROMPTS_TO_DEFAULT,
-                                default=False,
-                            ): bool,
+                                default=[],
+                            ): SelectSelector(
+                                SelectSelectorConfig(
+                                    options=[
+                                        SelectOptionDict(
+                                            value=CONF_INSTRUCTIONS_PROMPT,
+                                            label="Instructions Prompt",
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_PROMPT_BASE, label="Base Prompt"
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_PROMPT_NO_ENABLED_ENTITIES,
+                                            label="No Enabled Entities Prompt",
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_API_PROMPT_BASE,
+                                            label="API Base Prompt",
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_PROMPT_DEVICE_KNOWN_LOCATION,
+                                            label="Device Known Location Prompt",
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_PROMPT_DEVICE_UNKNOWN_LOCATION,
+                                            label="Device Unknown Location Prompt",
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_PROMPT_TIMERS_UNSUPPORTED,
+                                            label="Timers Unsupported Prompt",
+                                        ),
+                                        SelectOptionDict(
+                                            value=CONF_PROMPT_EXPOSED_ENTITIES,
+                                            label="Exposed Entities Prompt",
+                                        ),
+                                    ],
+                                    multiple=True,
+                                    sort=False,
+                                )
+                            ),
                         }
                     )
                 ),

--- a/custom_components/custom_conversation/config_flow.py
+++ b/custom_components/custom_conversation/config_flow.py
@@ -519,14 +519,23 @@ class CustomConversationOptionsFlow(OptionsFlow):
                 )
                 processed_input[CONF_IGNORED_INTENTS_SECTION] = ignored_intents_section
 
-            # If any of the custom prompts are an empty string, use the defaults
+            # ha-form omits an optional text field from the submitted data
+            # entirely when the user clears it, so a missing key here means
+            # the field was deliberately emptied, not that it was never
+            # configured (an options-flow re-edit always has prior values
+            # backing the schema's suggested_value). Preserve that as "",
+            # rather than reintroducing the old value or a hardcoded default.
             prompts = processed_input.get(CONF_CUSTOM_PROMPTS_SECTION, {})
-            for prompt in prompts:
-                if not prompts.get(prompt):
-                    prompts[prompt] = DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION].get(
-                        prompt
-                    )
+            for prompt_key in DEFAULT_OPTIONS[CONF_CUSTOM_PROMPTS_SECTION]:
+                prompts.setdefault(prompt_key, "")
             processed_input[CONF_CUSTOM_PROMPTS_SECTION] = prompts
+
+            langfuse_options = processed_input.get(CONF_LANGFUSE_SECTION, {})
+            for lf_key, lf_default in DEFAULT_OPTIONS[CONF_LANGFUSE_SECTION].items():
+                if lf_key not in langfuse_options:
+                    langfuse_options[lf_key] = "" if isinstance(lf_default, str) else lf_default
+            processed_input[CONF_LANGFUSE_SECTION] = langfuse_options
+
             return self.async_create_entry(title="", data=processed_input)
 
         # Build schema for options
@@ -600,69 +609,85 @@ class CustomConversationOptionsFlow(OptionsFlow):
                         {
                             vol.Optional(
                                 CONF_INSTRUCTIONS_PROMPT,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(
-                                    CONF_INSTRUCTIONS_PROMPT,
-                                    DEFAULT_INSTRUCTIONS_PROMPT,
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(
+                                        CONF_INSTRUCTIONS_PROMPT,
+                                        DEFAULT_INSTRUCTIONS_PROMPT,
+                                    )
+                                },
                             ): TemplateSelector(),
                             vol.Optional(
                                 CONF_PROMPT_BASE,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(CONF_PROMPT_BASE, DEFAULT_BASE_PROMPT),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(CONF_PROMPT_BASE, DEFAULT_BASE_PROMPT)
+                                },
                             ): TemplateSelector(),
                             vol.Optional(
                                 CONF_PROMPT_NO_ENABLED_ENTITIES,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(
-                                    CONF_PROMPT_NO_ENABLED_ENTITIES,
-                                    DEFAULT_PROMPT_NO_ENABLED_ENTITIES,
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(
+                                        CONF_PROMPT_NO_ENABLED_ENTITIES,
+                                        DEFAULT_PROMPT_NO_ENABLED_ENTITIES,
+                                    )
+                                },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                             vol.Optional(
                                 CONF_API_PROMPT_BASE,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(CONF_API_PROMPT_BASE, DEFAULT_API_PROMPT_BASE),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(CONF_API_PROMPT_BASE, DEFAULT_API_PROMPT_BASE)
+                                },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                             vol.Optional(
                                 CONF_PROMPT_DEVICE_KNOWN_LOCATION,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(
-                                    CONF_PROMPT_DEVICE_KNOWN_LOCATION,
-                                    DEFAULT_API_PROMPT_DEVICE_KNOWN_LOCATION,
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(
+                                        CONF_PROMPT_DEVICE_KNOWN_LOCATION,
+                                        DEFAULT_API_PROMPT_DEVICE_KNOWN_LOCATION,
+                                    )
+                                },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                             vol.Optional(
                                 CONF_PROMPT_DEVICE_UNKNOWN_LOCATION,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(
-                                    CONF_PROMPT_DEVICE_UNKNOWN_LOCATION,
-                                    DEFAULT_API_PROMPT_DEVICE_UNKNOWN_LOCATION,
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(
+                                        CONF_PROMPT_DEVICE_UNKNOWN_LOCATION,
+                                        DEFAULT_API_PROMPT_DEVICE_UNKNOWN_LOCATION,
+                                    )
+                                },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                             vol.Optional(
                                 CONF_PROMPT_TIMERS_UNSUPPORTED,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(
-                                    CONF_PROMPT_TIMERS_UNSUPPORTED,
-                                    DEFAULT_API_PROMPT_TIMERS_UNSUPPORTED,
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(
+                                        CONF_PROMPT_TIMERS_UNSUPPORTED,
+                                        DEFAULT_API_PROMPT_TIMERS_UNSUPPORTED,
+                                    )
+                                },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                             vol.Optional(
                                 CONF_PROMPT_EXPOSED_ENTITIES,
-                                default=options.get(
-                                    CONF_CUSTOM_PROMPTS_SECTION, {}
-                                ).get(
-                                    CONF_PROMPT_EXPOSED_ENTITIES,
-                                    DEFAULT_API_PROMPT_EXPOSED_ENTITIES,
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_CUSTOM_PROMPTS_SECTION, {}
+                                    ).get(
+                                        CONF_PROMPT_EXPOSED_ENTITIES,
+                                        DEFAULT_API_PROMPT_EXPOSED_ENTITIES,
+                                    )
+                                },
                             ): TextSelector(TextSelectorConfig(multiline=True)),
                         }
                     )
@@ -679,45 +704,59 @@ class CustomConversationOptionsFlow(OptionsFlow):
                             ): bool,
                             vol.Optional(
                                 CONF_LANGFUSE_HOST,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_HOST, ""
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_HOST, "")
+                                },
                             ): str,
                             vol.Optional(
                                 CONF_LANGFUSE_PUBLIC_KEY,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_PUBLIC_KEY, ""
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_PUBLIC_KEY, "")
+                                },
                             ): str,
                             vol.Optional(
                                 CONF_LANGFUSE_SECRET_KEY,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_SECRET_KEY, ""
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_SECRET_KEY, "")
+                                },
                             ): TextSelector(TextSelectorConfig(type="password")),
                             vol.Optional(
                                 CONF_LANGFUSE_BASE_PROMPT_ID,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_BASE_PROMPT_ID, ""
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_BASE_PROMPT_ID, "")
+                                },
                             ): str,
                             vol.Optional(
                                 CONF_LANGFUSE_BASE_PROMPT_LABEL,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_BASE_PROMPT_LABEL, "production"
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_BASE_PROMPT_LABEL, "production")
+                                },
                             ): str,
                             vol.Optional(
                                 CONF_LANGFUSE_API_PROMPT_ID,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_API_PROMPT_ID, ""
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_API_PROMPT_ID, "")
+                                },
                             ): str,
                             vol.Optional(
                                 CONF_LANGFUSE_API_PROMPT_LABEL,
-                                default=options.get(CONF_LANGFUSE_SECTION, {}).get(
-                                    CONF_LANGFUSE_API_PROMPT_LABEL, "production"
-                                ),
+                                description={
+                                    "suggested_value": options.get(
+                                        CONF_LANGFUSE_SECTION, {}
+                                    ).get(CONF_LANGFUSE_API_PROMPT_LABEL, "production")
+                                },
                             ): str,
                             vol.Optional(
                                 CONF_LANGFUSE_TRACING_ENABLED,

--- a/custom_components/custom_conversation/const.py
+++ b/custom_components/custom_conversation/const.py
@@ -45,6 +45,7 @@ CONVERSATION_ENDED_EVENT = f"{DOMAIN}_conversation_ended"
 CONVERSATION_ERROR_EVENT = f"{DOMAIN}_conversation_error"
 
 CONF_CUSTOM_PROMPTS_SECTION = "custom_prompts"
+CONF_RESET_PROMPTS_TO_DEFAULT = "reset_prompts_to_default"
 CONF_PROMPT_BASE = "prompt_base"
 DEFAULT_BASE_PROMPT = (
     'Current time is {{ now().strftime("%H:%M:%S") }}. '

--- a/custom_components/custom_conversation/strings.json
+++ b/custom_components/custom_conversation/strings.json
@@ -100,7 +100,7 @@
               "prompt_device_unknown_location": "Device Unknown Location Prompt",
               "prompt_timers_unsupported": "Timers Unsupported Prompt",
               "prompt_exposed_entities": "Exposed Entities Prompt",
-              "reset_prompts_to_default": "Reset all prompts above to their built-in defaults"
+              "reset_prompts_to_default": "Reset selected prompts to defaults"
             },
             "data_description": {
               "prompt_base": "The base prompt included in every LLM prompt. Can be a template.",
@@ -110,7 +110,7 @@
               "prompt_device_unknown_location": "The prompt the API uses with the request comes from a device whose area is unknown.",
               "prompt_timers_unsupported": "The prompt the API includes if the request comes from a device that cannot set timers.",
               "prompt_exposed_entities": "The prompt the API includes prior to the list of exposed entities and areas.",
-              "reset_prompts_to_default": "Leaving a prompt field blank saves it as empty (no prompt sent). Check this and save to restore the original built-in text for every prompt above instead."
+              "reset_prompts_to_default": "Leaving a prompt field blank saves it as empty (no prompt sent). Select a prompt here and save to restore just that field to its original built-in text, regardless of what is typed in the field above."
             }
           },
           "langfuse": {

--- a/custom_components/custom_conversation/strings.json
+++ b/custom_components/custom_conversation/strings.json
@@ -99,7 +99,8 @@
               "prompt_device_known_location": "Device Known Location Prompt",
               "prompt_device_unknown_location": "Device Unknown Location Prompt",
               "prompt_timers_unsupported": "Timers Unsupported Prompt",
-              "prompt_exposed_entities": "Exposed Entities Prompt"
+              "prompt_exposed_entities": "Exposed Entities Prompt",
+              "reset_prompts_to_default": "Reset all prompts above to their built-in defaults"
             },
             "data_description": {
               "prompt_base": "The base prompt included in every LLM prompt. Can be a template.",
@@ -108,7 +109,8 @@
               "prompt_device_known_location": "The prompt the API uses when the request comes from a device with a known area.  The '{{ location }}' variable will be replaced with the devices area and potentially floor.",
               "prompt_device_unknown_location": "The prompt the API uses with the request comes from a device whose area is unknown.",
               "prompt_timers_unsupported": "The prompt the API includes if the request comes from a device that cannot set timers.",
-              "prompt_exposed_entities": "The prompt the API includes prior to the list of exposed entities and areas."
+              "prompt_exposed_entities": "The prompt the API includes prior to the list of exposed entities and areas.",
+              "reset_prompts_to_default": "Leaving a prompt field blank saves it as empty (no prompt sent). Check this and save to restore the original built-in text for every prompt above instead."
             }
           },
           "langfuse": {

--- a/custom_components/custom_conversation/translations/en.json
+++ b/custom_components/custom_conversation/translations/en.json
@@ -100,7 +100,7 @@
               "prompt_device_unknown_location": "Device Unknown Location Prompt",
               "prompt_timers_unsupported": "Timers Unsupported Prompt",
               "prompt_exposed_entities": "Exposed Entities Prompt",
-              "reset_prompts_to_default": "Reset all prompts above to their built-in defaults"
+              "reset_prompts_to_default": "Reset selected prompts to defaults"
             },
             "data_description": {
               "prompt_base": "The base prompt included in every LLM prompt. Can be a template.",
@@ -110,7 +110,7 @@
               "prompt_device_unknown_location": "The prompt the API uses with the request comes from a device whose area is unknown.",
               "prompt_timers_unsupported": "The prompt the API includes if the request comes from a device that cannot set timers.",
               "prompt_exposed_entities": "The prompt the API includes prior to the list of exposed entities and areas.",
-              "reset_prompts_to_default": "Leaving a prompt field blank saves it as empty (no prompt sent). Check this and save to restore the original built-in text for every prompt above instead."
+              "reset_prompts_to_default": "Leaving a prompt field blank saves it as empty (no prompt sent). Select a prompt here and save to restore just that field to its original built-in text, regardless of what is typed in the field above."
             }
           },
           "langfuse": {

--- a/custom_components/custom_conversation/translations/en.json
+++ b/custom_components/custom_conversation/translations/en.json
@@ -99,7 +99,8 @@
               "prompt_device_known_location": "Device Known Location Prompt",
               "prompt_device_unknown_location": "Device Unknown Location Prompt",
               "prompt_timers_unsupported": "Timers Unsupported Prompt",
-              "prompt_exposed_entities": "Exposed Entities Prompt"
+              "prompt_exposed_entities": "Exposed Entities Prompt",
+              "reset_prompts_to_default": "Reset all prompts above to their built-in defaults"
             },
             "data_description": {
               "prompt_base": "The base prompt included in every LLM prompt. Can be a template.",
@@ -108,7 +109,8 @@
               "prompt_device_known_location": "The prompt the API uses when the request comes from a device with a known area.  The '{{ location }}' variable will be replaced with the devices area and potentially floor.",
               "prompt_device_unknown_location": "The prompt the API uses with the request comes from a device whose area is unknown.",
               "prompt_timers_unsupported": "The prompt the API includes if the request comes from a device that cannot set timers.",
-              "prompt_exposed_entities": "The prompt the API includes prior to the list of exposed entities and areas."
+              "prompt_exposed_entities": "The prompt the API includes prior to the list of exposed entities and areas.",
+              "reset_prompts_to_default": "Leaving a prompt field blank saves it as empty (no prompt sent). Check this and save to restore the original built-in text for every prompt above instead."
             }
           },
           "langfuse": {

--- a/unit_tests/test_config_flow.py
+++ b/unit_tests/test_config_flow.py
@@ -33,6 +33,7 @@ from custom_components.custom_conversation.const import (
     CONF_PROMPT_EXPOSED_ENTITIES,
     CONF_PROMPT_NO_ENABLED_ENTITIES,
     CONF_PROMPT_TIMERS_UNSUPPORTED,
+    CONF_RESET_PROMPTS_TO_DEFAULT,
     CONF_SECONDARY_PROVIDER_ENABLED,
     CONF_TEMPERATURE,
     CONF_TOP_P,
@@ -265,8 +266,8 @@ async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry):
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_BASE_PROMPT_ID] == "test-base-prompt-id"
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_API_PROMPT_ID] == "test-api-prompt-id"
 
-async def test_options_flow_empty_fields_reset(hass: HomeAssistant, config_entry):
-    """Test config flow options with empty fields reset to recommended."""
+async def test_options_flow_empty_fields_stay_empty(hass: HomeAssistant, config_entry):
+    """Test config flow options: blank prompt/langfuse fields save as explicit empty, not defaults."""
 
     config_entry.add_to_hass(hass)
 
@@ -326,15 +327,15 @@ async def test_options_flow_empty_fields_reset(hass: HomeAssistant, config_entry
         assert result["data"][CONF_TEMPERATURE] == 0.5
         assert result["data"][CONF_TOP_P] == 0.5
         assert result["data"][CONF_MAX_TOKENS] == 50
-        # Assert other sections
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_INSTRUCTIONS_PROMPT].strip() == DEFAULT_INSTRUCTIONS_PROMPT.strip()
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_BASE] == DEFAULT_BASE_PROMPT
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_NO_ENABLED_ENTITIES] == DEFAULT_PROMPT_NO_ENABLED_ENTITIES
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_API_PROMPT_BASE] == DEFAULT_API_PROMPT_BASE
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_DEVICE_KNOWN_LOCATION] == DEFAULT_API_PROMPT_DEVICE_KNOWN_LOCATION
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_DEVICE_UNKNOWN_LOCATION] == DEFAULT_API_PROMPT_DEVICE_UNKNOWN_LOCATION
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_TIMERS_UNSUPPORTED] == DEFAULT_API_PROMPT_TIMERS_UNSUPPORTED
-        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_EXPOSED_ENTITIES] == DEFAULT_API_PROMPT_EXPOSED_ENTITIES
+        # Assert other sections: blank fields save as explicit empty, not defaults
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_INSTRUCTIONS_PROMPT] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_BASE] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_NO_ENABLED_ENTITIES] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_API_PROMPT_BASE] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_DEVICE_KNOWN_LOCATION] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_DEVICE_UNKNOWN_LOCATION] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_TIMERS_UNSUPPORTED] == ""
+        assert result["data"][CONF_CUSTOM_PROMPTS_SECTION][CONF_PROMPT_EXPOSED_ENTITIES] == ""
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_ENABLE_LANGFUSE] is False
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_SECRET_KEY] == ""
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_PUBLIC_KEY] == ""
@@ -342,6 +343,68 @@ async def test_options_flow_empty_fields_reset(hass: HomeAssistant, config_entry
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_BASE_PROMPT_ID] == ""
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_API_PROMPT_ID] == ""
         assert result["data"][CONF_LANGFUSE_SECTION][CONF_LANGFUSE_TRACING_ENABLED] is False
+
+
+async def test_options_flow_reset_prompts_to_default(hass: HomeAssistant, config_entry):
+    """Test the reset checkbox restores built-in prompt defaults, overriding any submitted values."""
+
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.custom_conversation.async_setup", return_value=True
+    ), patch(
+        "custom_components.custom_conversation.async_setup_entry",
+        return_value=True,
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_LLM_HASS_API: "none",
+                CONF_IGNORED_INTENTS_SECTION: {
+                    CONF_IGNORED_INTENTS: [],
+                },
+                CONF_AGENTS_SECTION: {
+                    CONF_ENABLE_HASS_AGENT: True,
+                    CONF_ENABLE_LLM_AGENT: False,
+                },
+                CONF_TEMPERATURE: 0.5,
+                CONF_TOP_P: 0.5,
+                CONF_MAX_TOKENS: 50,
+                CONF_CUSTOM_PROMPTS_SECTION: {
+                    CONF_INSTRUCTIONS_PROMPT: "some custom text that should be discarded",
+                    CONF_PROMPT_BASE: "",
+                    CONF_PROMPT_NO_ENABLED_ENTITIES: "",
+                    CONF_API_PROMPT_BASE: "",
+                    CONF_PROMPT_DEVICE_KNOWN_LOCATION: "",
+                    CONF_PROMPT_DEVICE_UNKNOWN_LOCATION: "",
+                    CONF_PROMPT_TIMERS_UNSUPPORTED: "",
+                    CONF_PROMPT_EXPOSED_ENTITIES: "",
+                    CONF_RESET_PROMPTS_TO_DEFAULT: True,
+                },
+                CONF_LANGFUSE_SECTION: {
+                    CONF_ENABLE_LANGFUSE: False,
+                    CONF_LANGFUSE_SECRET_KEY: "",
+                    CONF_LANGFUSE_PUBLIC_KEY: "",
+                    CONF_LANGFUSE_HOST: "",
+                    CONF_LANGFUSE_BASE_PROMPT_ID: "",
+                    CONF_LANGFUSE_API_PROMPT_ID: "",
+                    CONF_LANGFUSE_TRACING_ENABLED: False,
+                },
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        prompts = result["data"][CONF_CUSTOM_PROMPTS_SECTION]
+        assert prompts[CONF_INSTRUCTIONS_PROMPT].strip() == DEFAULT_INSTRUCTIONS_PROMPT.strip()
+        assert prompts[CONF_PROMPT_BASE] == DEFAULT_BASE_PROMPT
+        assert prompts[CONF_PROMPT_NO_ENABLED_ENTITIES] == DEFAULT_PROMPT_NO_ENABLED_ENTITIES
+        assert prompts[CONF_API_PROMPT_BASE] == DEFAULT_API_PROMPT_BASE
+        assert prompts[CONF_PROMPT_DEVICE_KNOWN_LOCATION] == DEFAULT_API_PROMPT_DEVICE_KNOWN_LOCATION
+        assert prompts[CONF_PROMPT_DEVICE_UNKNOWN_LOCATION] == DEFAULT_API_PROMPT_DEVICE_UNKNOWN_LOCATION
+        assert prompts[CONF_PROMPT_TIMERS_UNSUPPORTED] == DEFAULT_API_PROMPT_TIMERS_UNSUPPORTED
+        assert prompts[CONF_PROMPT_EXPOSED_ENTITIES] == DEFAULT_API_PROMPT_EXPOSED_ENTITIES
+        assert CONF_RESET_PROMPTS_TO_DEFAULT not in prompts
 
 
 async def test_options_flow_ignored_intents(hass: HomeAssistant, config_entry):

--- a/unit_tests/test_config_flow.py
+++ b/unit_tests/test_config_flow.py
@@ -346,7 +346,7 @@ async def test_options_flow_empty_fields_stay_empty(hass: HomeAssistant, config_
 
 
 async def test_options_flow_reset_prompts_to_default(hass: HomeAssistant, config_entry):
-    """Test the reset checkbox restores built-in prompt defaults, overriding any submitted values."""
+    """Test the reset multi-select restores built-in defaults only for the selected prompt fields."""
 
     config_entry.add_to_hass(hass)
 
@@ -381,7 +381,10 @@ async def test_options_flow_reset_prompts_to_default(hass: HomeAssistant, config
                     CONF_PROMPT_DEVICE_UNKNOWN_LOCATION: "",
                     CONF_PROMPT_TIMERS_UNSUPPORTED: "",
                     CONF_PROMPT_EXPOSED_ENTITIES: "",
-                    CONF_RESET_PROMPTS_TO_DEFAULT: True,
+                    CONF_RESET_PROMPTS_TO_DEFAULT: [
+                        CONF_INSTRUCTIONS_PROMPT,
+                        CONF_PROMPT_BASE,
+                    ],
                 },
                 CONF_LANGFUSE_SECTION: {
                     CONF_ENABLE_LANGFUSE: False,
@@ -396,14 +399,16 @@ async def test_options_flow_reset_prompts_to_default(hass: HomeAssistant, config
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
         prompts = result["data"][CONF_CUSTOM_PROMPTS_SECTION]
+        # Selected fields: reset to default, ignoring what was submitted
         assert prompts[CONF_INSTRUCTIONS_PROMPT].strip() == DEFAULT_INSTRUCTIONS_PROMPT.strip()
         assert prompts[CONF_PROMPT_BASE] == DEFAULT_BASE_PROMPT
-        assert prompts[CONF_PROMPT_NO_ENABLED_ENTITIES] == DEFAULT_PROMPT_NO_ENABLED_ENTITIES
-        assert prompts[CONF_API_PROMPT_BASE] == DEFAULT_API_PROMPT_BASE
-        assert prompts[CONF_PROMPT_DEVICE_KNOWN_LOCATION] == DEFAULT_API_PROMPT_DEVICE_KNOWN_LOCATION
-        assert prompts[CONF_PROMPT_DEVICE_UNKNOWN_LOCATION] == DEFAULT_API_PROMPT_DEVICE_UNKNOWN_LOCATION
-        assert prompts[CONF_PROMPT_TIMERS_UNSUPPORTED] == DEFAULT_API_PROMPT_TIMERS_UNSUPPORTED
-        assert prompts[CONF_PROMPT_EXPOSED_ENTITIES] == DEFAULT_API_PROMPT_EXPOSED_ENTITIES
+        # Unselected fields: submitted blank stays blank, not reset
+        assert prompts[CONF_PROMPT_NO_ENABLED_ENTITIES] == ""
+        assert prompts[CONF_API_PROMPT_BASE] == ""
+        assert prompts[CONF_PROMPT_DEVICE_KNOWN_LOCATION] == ""
+        assert prompts[CONF_PROMPT_DEVICE_UNKNOWN_LOCATION] == ""
+        assert prompts[CONF_PROMPT_TIMERS_UNSUPPORTED] == ""
+        assert prompts[CONF_PROMPT_EXPOSED_ENTITIES] == ""
         assert CONF_RESET_PROMPTS_TO_DEFAULT not in prompts
 
 


### PR DESCRIPTION
## Problem

Clearing any optional text/template field in the **Custom Prompts** or **Langfuse** sections of the options flow (e.g. Base Prompt, Langfuse Host) and saving appeared to silently discard the change: reopening the dialog showed the previous value again, not empty. This made it impossible to intentionally leave one of these fields blank (e.g. to opt out of the default `prompt_base` date/time injection).

## Root cause

Home Assistant's frontend omits an optional text field from the submitted payload entirely when the user clears it. Home Assistant core then re-validates that payload against the step's voluptuous schema *before* the integration's own step handler ever runs. Because these fields were declared with a dynamic `default=` bound to the entry's current (pre-save) option value, voluptuous silently refilled the missing key with that old value during this re-validation — so by the time `async_step_init` saw the data, the "cleared" field already contained its previous content again, indistinguishable from the user having resubmitted it unchanged.

An earlier fix attempt for the Custom Prompts section addressed only the integration's own post-processing step, which never actually ran on the corrupted path since voluptuous had already backfilled the old value further upstream.

## Fix

Replace the dynamic `default=` with `description={"suggested_value": ...}` for every optional text/template field in the Custom Prompts and Langfuse sections. This still pre-fills the form with the current value for display, but no longer causes voluptuous to reintroduce it when the field is cleared — an absent key now unambiguously means "the user submitted this field empty". The options-flow handler then preserves that as an explicit empty string instead of falling back to old data or a hardcoded default.

## Testing

- Verified via debug logging against the running integration that the raw payload HA hands to `async_step_init` now omits a cleared field's key entirely (previously showed the stale old value), and that the saved entry stores it as `""` afterwards.
- Live-tested end-to-end in the options flow UI: clearing Base Prompt, saving, and reopening the dialog now correctly shows an empty field instead of the old prompt text.

---

One of several independent PRs from the same debugging session (see #106, #107); kept separate per repo maintainer preference for small, focused PRs.
