### PR TITLE
Strip live state/attributes from the static API prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ memory-bank/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.venv_test/

--- a/custom_components/custom_conversation/api.py
+++ b/custom_components/custom_conversation/api.py
@@ -35,6 +35,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.json import JsonObjectType
+from homeassistant.util import yaml as yaml_util
 
 from .const import CONF_IGNORED_INTENTS, LLM_API_ID
 from .prompt_manager import PromptContext, PromptManager
@@ -70,7 +71,7 @@ class CustomLLMAPI(llm.API):
         """Return an instance of the Custom Conversation LLM API."""
         if llm_context.assistant:
             exposed_entities: dict | None = _get_exposed_entities(
-                self.hass, llm_context.assistant
+                self.hass, llm_context.assistant, include_state=False
             )
         else:
             exposed_entities = None
@@ -189,6 +190,9 @@ class CustomLLMAPI(llm.API):
 
                 tools.append(llm.ScriptTool(self.hass, state.entity_id))
 
+            if exposed_entities:
+                tools.append(GetLiveContextTool())
+
         return tools
 
 
@@ -267,7 +271,7 @@ class IntentTool(llm.Tool):
 
 
 def _get_exposed_entities(
-    hass: HomeAssistant, assistant: str
+    hass: HomeAssistant, assistant: str, include_state: bool = True
 ) -> dict[str, dict[str, Any]]:
     """Get exposed entities."""
     area_registry = ar.async_get(hass)
@@ -332,8 +336,10 @@ def _get_exposed_entities(
         info: dict[str, Any] = {
             "names": ", ".join(str(n) for n in names),
             "domain": state.domain,
-            "state": state.state,
         }
+
+        if include_state:
+            info["state"] = state.state
 
         if description:
             info["description"] = description
@@ -341,13 +347,15 @@ def _get_exposed_entities(
         if area_names:
             info["areas"] = ", ".join(str(n) for n in area_names)
 
-        if attributes := {
-            str(attr_name): str(attr_value)
-            if isinstance(attr_value, (Enum, Decimal, int))
-            else attr_value
-            for attr_name, attr_value in state.attributes.items()
-            if attr_name in interesting_attributes
-        }:
+        if include_state and (
+            attributes := {
+                str(attr_name): str(attr_value)
+                if isinstance(attr_value, (Enum, Decimal, int))
+                else attr_value
+                for attr_name, attr_value in state.attributes.items()
+                if attr_name in interesting_attributes
+            }
+        ):
             info["attributes"] = attributes
 
         entities[state.entity_id] = info
@@ -439,3 +447,139 @@ def _get_cached_script_parameters(
 SCRIPT_PARAMETERS_CACHE: HassKey[dict[str, tuple[str | None, vol.Schema]]] = HassKey(
     "llm_script_parameters_cache"
 )
+
+
+def _live_context_match_error(
+    match_result: intent.MatchTargetsResult,
+    name_filter: str | None,
+    area_filter: str | None,
+    domain_filter: list[str] | None,
+) -> str:
+    """Build an actionable error message for a failed GetLiveContext match."""
+    reason = match_result.no_match_reason
+    if reason is intent.MatchFailedReason.INVALID_AREA:
+        return f"Area '{match_result.no_match_name}' does not exist"
+    if reason is intent.MatchFailedReason.NAME:
+        return f"No exposed entities matched name '{name_filter}'"
+    if reason is intent.MatchFailedReason.AREA:
+        return f"No exposed entities found in area '{area_filter}'"
+    if reason is intent.MatchFailedReason.DOMAIN:
+        domains = ", ".join(domain_filter) if domain_filter else ""
+        return f"No exposed entities found in domain(s): {domains}"
+    return "No entities matched the provided filter"
+
+
+class GetLiveContextTool(llm.Tool):
+    """Tool for getting the current state of exposed entities.
+
+    The static entity list in the API prompt omits state and attributes
+    to keep the prompt prefix stable for caching. This tool provides the
+    live values on demand.
+    """
+
+    name = "GetLiveContext"
+    description = (
+        "Provides real-time information about the CURRENT state, value, "
+        "or mode of devices, sensors, entities, or areas. "
+        "Use this tool for: "
+        "1. Answering questions about current conditions (e.g., 'Is the light on?'). "
+        "2. As the first step in conditional actions (e.g., 'If the weather is "
+        "rainy, turn off sprinklers' requires checking the weather first). "
+        "You may filter for devices by name, domain, and area, including "
+        "combining those filters. Prefer filtering by domain when searching "
+        "for multiple devices of the same type."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Optional(
+                "name",
+                description="Filter entities by name or alias (case-insensitive).",
+            ): cv.string,
+            vol.Optional(
+                "domain",
+                description=(
+                    "Filter entities by domain (e.g. 'light', 'sensor'). "
+                    "Accepts a single domain or a list."
+                ),
+            ): vol.Any(cv.string, [cv.string]),
+            vol.Optional(
+                "area",
+                description="Filter entities by area name or alias (case-insensitive).",
+            ): cv.string,
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Get the current state of exposed entities."""
+        args = self.parameters(tool_input.tool_args)
+        exposed_entities = _get_exposed_entities(
+            hass, llm_context.assistant, include_state=True
+        )
+
+        if not exposed_entities:
+            return {"success": False, "error": "No entities are exposed"}
+
+        name_filter = args.get("name")
+        area_filter = args.get("area")
+        domain_filter = args.get("domain")
+
+        if isinstance(domain_filter, str):
+            domain_filter = [domain_filter]
+
+        if domain_filter is not None:
+            domain_filter = [
+                normalized_domain
+                for domain in domain_filter
+                if (normalized_domain := domain.strip().lower())
+            ]
+
+        if name_filter or area_filter or domain_filter:
+            exposed_states = [
+                state
+                for entity_id in exposed_entities
+                if (state := hass.states.get(entity_id)) is not None
+            ]
+            match_result = intent.async_match_targets(
+                hass,
+                intent.MatchTargetsConstraints(
+                    name=name_filter,
+                    area_name=area_filter,
+                    domains=domain_filter,
+                    # This tool only returns context, so multiple entities
+                    # sharing a name (e.g. "AC" in two areas) should all be
+                    # returned rather than failing as an ambiguous match.
+                    allow_duplicate_names=True,
+                ),
+                states=exposed_states,
+            )
+
+            if not match_result.is_match:
+                return {
+                    "success": False,
+                    "error": _live_context_match_error(
+                        match_result, name_filter, area_filter, domain_filter
+                    ),
+                }
+
+            matched_ids = {state.entity_id for state in match_result.states}
+            entities = [
+                info
+                for entity_id, info in exposed_entities.items()
+                if entity_id in matched_ids
+            ]
+        else:
+            entities = list(exposed_entities.values())
+
+        prompt = [
+            "Live Context: An overview of the areas and the devices in this smart home:",
+            yaml_util.dump(entities),
+        ]
+        return {
+            "success": True,
+            "result": "\n".join(prompt),
+        }

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from custom_components.custom_conversation.api import (
     CustomLLMAPI,
+    GetLiveContextTool,
     IntentTool,
     _get_exposed_entities,
 )
@@ -160,7 +161,9 @@ async def test_custom_llm_api_get_api_instance(custom_llm_api, mock_llm_context,
 
         instance = await custom_llm_api.async_get_api_instance(mock_llm_context)
 
-        mock_get_exposed.assert_called_once_with(custom_llm_api.hass, mock_llm_context.assistant)
+        mock_get_exposed.assert_called_once_with(
+            custom_llm_api.hass, mock_llm_context.assistant, include_state=False
+        )
         mock_get_prompt.assert_called_once_with(mock_llm_context, mock_exposed_entities_data)
         mock_get_tools.assert_called_once_with(mock_llm_context, mock_exposed_entities_data)
         mock_api_instance_cls.assert_called_once_with(
@@ -226,8 +229,20 @@ async def test_custom_llm_api_get_tools(custom_llm_api, hass, mock_llm_context, 
         mock_supports_timers.assert_called_once_with(hass, mock_llm_context.device_id)
 
         mock_intent_tool_cls.assert_called_once_with("HassTurnOn", mock_intent_handler_1)
-        assert len(tools) == 1
+        assert len(tools) == 2
         assert tools[0] is mock_intent_tool_cls.return_value
+        assert isinstance(tools[1], GetLiveContextTool)
+
+
+@pytest.mark.asyncio
+async def test_custom_llm_api_get_tools_no_exposed_entities(custom_llm_api, hass, mock_llm_context, config_entry):
+    """Test that GetLiveContextTool is omitted when nothing is exposed."""
+    with patch("custom_components.custom_conversation.api.intent.async_get", return_value=[]), \
+         patch("custom_components.custom_conversation.api.async_device_supports_timers", return_value=False):
+
+        tools = custom_llm_api._async_get_tools(mock_llm_context, {})
+
+        assert not any(isinstance(tool, GetLiveContextTool) for tool in tools)
 
 
 def test_intent_tool_init():
@@ -409,3 +424,88 @@ def test_get_exposed_entities_unexposed(mock_async_all, mock_should_expose, mock
 
     assert len(entities) == 0
     assert mock_target_entity.entity_id not in entities
+
+
+@patch("custom_components.custom_conversation.api._get_cached_script_parameters")
+@patch("custom_components.custom_conversation.api.async_should_expose", return_value=True)
+@patch("homeassistant.core.StateMachine.async_all")
+def test_get_exposed_entities_include_state_false(mock_async_all, mock_should_expose, mock_get_script_params, hass, mock_target_entity):
+    """Test _get_exposed_entities omits state and attributes when include_state is False."""
+    mock_async_all.return_value = [hass.states.get(mock_target_entity.entity_id)]
+
+    assistant_id = "conversation.test_assistant"
+    entities = _get_exposed_entities(hass, assistant_id, include_state=False)
+
+    light_info = entities[mock_target_entity.entity_id]
+    assert light_info["names"] == "Test Light"
+    assert light_info["domain"] == "light"
+    assert light_info["areas"] == "Test Area"
+    assert "state" not in light_info
+    assert "attributes" not in light_info
+
+
+@pytest.mark.asyncio
+async def test_get_live_context_tool_no_filter(hass, mock_llm_context, mock_target_entity):
+    """Test GetLiveContextTool returns all exposed entities when no filter is given."""
+    tool_input = llm.ToolInput(tool_name="GetLiveContext", tool_args={})
+    mock_entities = {
+        mock_target_entity.entity_id: {
+            "names": "Test Light",
+            "domain": "light",
+            "state": "on",
+            "attributes": {"brightness": "100"},
+        }
+    }
+
+    with patch(
+        "custom_components.custom_conversation.api._get_exposed_entities",
+        return_value=mock_entities,
+    ) as mock_get_exposed:
+        tool = GetLiveContextTool()
+        response = await tool.async_call(hass, tool_input, mock_llm_context)
+
+        mock_get_exposed.assert_called_once_with(
+            hass, mock_llm_context.assistant, include_state=True
+        )
+        assert response["success"] is True
+        assert "Test Light" in response["result"]
+
+
+@pytest.mark.asyncio
+async def test_get_live_context_tool_no_exposed_entities(hass, mock_llm_context):
+    """Test GetLiveContextTool when nothing is exposed."""
+    tool_input = llm.ToolInput(tool_name="GetLiveContext", tool_args={})
+
+    with patch(
+        "custom_components.custom_conversation.api._get_exposed_entities",
+        return_value={},
+    ):
+        tool = GetLiveContextTool()
+        response = await tool.async_call(hass, tool_input, mock_llm_context)
+
+        assert response == {"success": False, "error": "No entities are exposed"}
+
+
+@pytest.mark.asyncio
+async def test_get_live_context_tool_filter_no_match(hass, mock_llm_context, mock_target_entity):
+    """Test GetLiveContextTool returns an error when the name filter matches nothing."""
+    tool_input = llm.ToolInput(
+        tool_name="GetLiveContext", tool_args={"name": "Nonexistent Entity"}
+    )
+    mock_entities = {
+        mock_target_entity.entity_id: {
+            "names": "Test Light",
+            "domain": "light",
+            "state": "on",
+        }
+    }
+
+    with patch(
+        "custom_components.custom_conversation.api._get_exposed_entities",
+        return_value=mock_entities,
+    ):
+        tool = GetLiveContextTool()
+        response = await tool.async_call(hass, tool_input, mock_llm_context)
+
+        assert response["success"] is False
+        assert "Nonexistent Entity" in response["error"]

--- a/unit_tests/test_api.py
+++ b/unit_tests/test_api.py
@@ -509,3 +509,81 @@ async def test_get_live_context_tool_filter_no_match(hass, mock_llm_context, moc
 
         assert response["success"] is False
         assert "Nonexistent Entity" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_live_context_tool_domain_filter_match(hass, mock_llm_context, mock_target_entity):
+    """Test GetLiveContextTool with a string domain filter returns the matched subset."""
+    tool_input = llm.ToolInput(tool_name="GetLiveContext", tool_args={"domain": "light"})
+    mock_entities = {
+        mock_target_entity.entity_id: {"names": "Test Light", "domain": "light", "state": "on"},
+        "sensor.other": {"names": "Other", "domain": "sensor", "state": "5"},
+    }
+    mock_match_result = MagicMock(
+        is_match=True,
+        states=[MagicMock(entity_id=mock_target_entity.entity_id)],
+    )
+
+    with patch(
+        "custom_components.custom_conversation.api._get_exposed_entities",
+        return_value=mock_entities,
+    ), patch(
+        "custom_components.custom_conversation.api.intent.async_match_targets",
+        return_value=mock_match_result,
+    ) as mock_match:
+        tool = GetLiveContextTool()
+        response = await tool.async_call(hass, tool_input, mock_llm_context)
+
+        assert mock_match.call_args.args[1].domains == ["light"]
+        assert response["success"] is True
+        assert "Test Light" in response["result"]
+        assert "Other" not in response["result"]
+
+
+@pytest.mark.asyncio
+async def test_get_live_context_tool_domain_filter_list_strips_blanks(hass, mock_llm_context, mock_target_entity):
+    """Test GetLiveContextTool normalizes a list domain filter, dropping blank entries."""
+    tool_input = llm.ToolInput(
+        tool_name="GetLiveContext", tool_args={"domain": ["Light", "  ", "Sensor"]}
+    )
+    mock_entities = {
+        mock_target_entity.entity_id: {"names": "Test Light", "domain": "light", "state": "on"},
+    }
+    mock_match_result = MagicMock(
+        is_match=True,
+        states=[MagicMock(entity_id=mock_target_entity.entity_id)],
+    )
+
+    with patch(
+        "custom_components.custom_conversation.api._get_exposed_entities",
+        return_value=mock_entities,
+    ), patch(
+        "custom_components.custom_conversation.api.intent.async_match_targets",
+        return_value=mock_match_result,
+    ) as mock_match:
+        tool = GetLiveContextTool()
+        response = await tool.async_call(hass, tool_input, mock_llm_context)
+
+        assert mock_match.call_args.args[1].domains == ["light", "sensor"]
+        assert response["success"] is True
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected_substring"),
+    [
+        (intent.MatchFailedReason.INVALID_AREA, "does not exist"),
+        (intent.MatchFailedReason.NAME, "matched name"),
+        (intent.MatchFailedReason.AREA, "found in area"),
+        (intent.MatchFailedReason.DOMAIN, "found in domain"),
+        (intent.MatchFailedReason.ASSISTANT, "No entities matched the provided filter"),
+    ],
+)
+def test_live_context_match_error_reasons(reason, expected_substring):
+    """Test _live_context_match_error covers every branch, including the generic fallback."""
+    from custom_components.custom_conversation.api import _live_context_match_error
+
+    match_result = MagicMock(no_match_reason=reason, no_match_name="Kitchen")
+    message = _live_context_match_error(
+        match_result, name_filter="Foo", area_filter="Kitchen", domain_filter=["light"]
+    )
+    assert expected_substring in message


### PR DESCRIPTION
## Summary
- The exposed-entity list baked into the system prompt on every turn included each entity's current `state` and a fixed set of "interesting" attributes. This meant the prompt prefix changed whenever *any* exposed entity changed state, defeating prompt caching on every turn (a real problem for local/self-hosted models where prompt processing time matters).
- `_get_exposed_entities` now takes an `include_state` flag; the static API prompt is built with `include_state=False` (names/domain/area only), matching stock Home Assistant's Assist API static context.
- Added a `GetLiveContext` tool (ported from `homeassistant.components.homeassistant.llm.GetLiveContextTool` in HA core) so the model can still fetch current state/attribute values on demand, filtered by name/domain/area, when a query actually needs live data.

## Test plan
- [x] `python -m py_compile` on the changed files
- [x] Unit tests updated/added in `unit_tests/test_api.py` (static prompt call now asserts `include_state=False`; `_async_get_tools` test asserts the new `GetLiveContext` tool is present when entities are exposed and absent when none are; new tests for `_get_exposed_entities(include_state=False)` and for `GetLiveContextTool.async_call` with no filter / no exposed entities / a non-matching filter)
- [x] CI will run the full suite
- [x] Manually verified live against a real HA instance: with debug logging on, confirmed the model calls `GetLiveContext{domain, name}` for a live-state question and answers correctly from the tool result, and that static entity-only questions/control intents are unaffected