### PR TITLE
Fix CI: drop exact python_full_version pin blocking pipenv install

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,3 @@ dbus-fast = "*"
 
 [requires]
 python_version = "3.14"
-python_full_version = "3.14.3"


### PR DESCRIPTION
## Summary
- CI (`test.yml`) currently fails for every PR before any tests run: `pipenv install --dev --skip-lock` errors out because `Pipfile` pins `python_full_version = "3.14.3"` exactly, while the `actions/setup-python@v5` step with `python-version: '3.14'` now resolves to a newer patch (currently `3.14.6`). Pipenv enforces the full-version pin exactly and there's no pyenv/asdf on the runner to fetch the older patch, so it aborts with "Neither 'pyenv' nor 'asdf' could be found to install Python."
- Since the two Codecov upload steps run with `if: ${{ !cancelled() }}`, they still execute after the failed install/skipped test step and fail again with "No coverage reports found" -- so the job shows red for reasons unrelated to the actual test suite (see e.g. #103, where CI failed with no test-related errors in the log at all).
- Dropping the exact `python_full_version` pin and keeping just `python_version = "3.14"` is enough for pipenv to accept whatever 3.14.x patch is installed, and avoids re-breaking on every future 3.14 patch release.

## Test plan
- [x] Confirmed via `gh run view --log` on the failing run for #103 that the failure is `pipenv install --dev --skip-lock` exiting 1 on the missing exact patch version, not a test/assertion failure
- [x] CI on this PR will confirm `pipenv install` and the test job now proceed past that step